### PR TITLE
Speedup __getitem__ and ensure consistent KeyErrors

### DIFF
--- a/zookeeper/hparam.py
+++ b/zookeeper/hparam.py
@@ -43,7 +43,7 @@ class HParams(collections.abc.Mapping):
     ```
     """
 
-    _private_methods = {"get", "items", "keys", "parse", "values"}
+    _abc_methods = {"get", "items", "keys", "parse", "values"}
 
     def parse(self, value):
         """Override existing hyperparameter values, parsing new values from a string.
@@ -68,16 +68,18 @@ class HParams(collections.abc.Mapping):
                 raise ValueError(f"Could not parse '{value}'") from None
             object.__setattr__(self, key, value)
 
+    def _is_hparam(self, item):
+        return item not in self._abc_methods and not item.startswith("_")
+
     def __iter__(self):
-        return (
-            k
-            for k in self.__dir__()
-            if k not in self._private_methods and not k.startswith("_")
-        )
+        return (item for item in self.__dir__() if self._is_hparam(item))
 
     def __getitem__(self, item):
-        if item in self.__iter__():
-            return getattr(self, item)
+        try:
+            if self._is_hparam(item):
+                return getattr(self, item)
+        except:
+            pass
         raise KeyError(item)
 
     def __len__(self):

--- a/zookeeper/hparam_test.py
+++ b/zookeeper/hparam_test.py
@@ -46,9 +46,11 @@ def test_immutability(hyper):
         hyper.new_prop = 3
 
 
-def test_get_private_methods(hyper):
+def test_key_error(hyper):
     with pytest.raises(KeyError):
         hyper["__dict__"]
+    with pytest.raises(KeyError):
+        hyper["unknown"]
 
 
 def test_repr(hyper):


### PR DESCRIPTION
This removes unnecessary loops and ensures that `__getitem__` properly throws `KeyError`s instead of `AttributeError`s