### PR TITLE
Fix recursion error in str and repr

### DIFF
--- a/zookeeper/hparam.py
+++ b/zookeeper/hparam.py
@@ -16,6 +16,12 @@ def group(sequence):
     return zip(*[iter(sequence)] * 2)
 
 
+def str_key_val(key, value, color=True):
+    if callable(value):
+        value = "<callable>"
+    return f"{BLUE}{key}{RESET}={YELLOW}{value}{RESET}" if color else f"{key}={value}"
+
+
 class HParams(collections.abc.Mapping):
     """Class to hold a set of immutable hyperparameters as name-value pairs.
 
@@ -87,11 +93,11 @@ class HParams(collections.abc.Mapping):
         raise AttributeError("Hyperparameters are immutable, cannot assign to field.")
 
     def __str__(self):
-        tab = "\n    "
-        params = f",{tab}".join(
-            [f"{BLUE}{k}{RESET}={YELLOW}{v}{RESET}" for k, v in sorted(self.items())]
-        )
-        return f"{self.__class__.__name__}({tab}{params}\n)"
+        params = ",\n    ".join([str_key_val(k, v) for k, v in sorted(self.items())])
+        return f"{self.__class__.__name__}(\n    {params}\n)"
 
     def __repr__(self):
-        return self.__str__()
+        params = ",".join(
+            [str_key_val(k, v, color=False) for k, v in sorted(self.items())]
+        )
+        return f"{self.__class__.__name__}({params})"

--- a/zookeeper/hparam_test.py
+++ b/zookeeper/hparam_test.py
@@ -16,6 +16,9 @@ def hyper():
         def barx2(self):
             return self.bar * 2
 
+        def bar_func(self):
+            return self.bar
+
     return Hyper()
 
 
@@ -24,6 +27,7 @@ def test_defaults(hyper):
     assert hyper.bar == 0.5
     assert hyper.barx2 == 1.0
     assert hyper.baz == "string"
+    assert hyper.bar_func() == hyper.bar
 
 
 def test_parse(hyper):
@@ -32,6 +36,7 @@ def test_parse(hyper):
     assert hyper.bar == 1.0
     assert hyper.barx2 == 2.0
     assert hyper.baz == "changed"
+    assert hyper.bar_func() == hyper.bar
 
 
 def test_parse_fail(hyper):
@@ -52,11 +57,16 @@ def test_get_private_methods(hyper):
 
 
 def test_repr(hyper):
+    output = "Hyper(bar=0.5,bar_func=<callable>,barx2=1.0,baz=string,foo=[1, 2, 3])"
+    assert repr(hyper) == output
+
+
+def test_str(hyper):
     output = """Hyper(
     bar=0.5,
+    bar_func=<callable>,
     barx2=1.0,
     baz=string,
     foo=[1, 2, 3]
 )"""
     assert click.unstyle(str(hyper)) == output
-    assert click.unstyle(repr(hyper)) == output


### PR DESCRIPTION
This strips colors from `__repr__` and fixes a recursion error due occuring when with functions in as hyperparameters.