### PR TITLE
Test against Python 3.6/3.7 and TF 1.13.1/1.14.0/2.0-beta1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,12 +10,15 @@ jobs:
       vmImage: "Ubuntu-16.04"
     strategy:
       matrix:
-        Python37:
-          python.version: "3.7"
+        Python36_TF113:
+          python.version: "3.6"
           tensorflow.version: "1.13.1"
-        Python37TF2:
+        Python37_TF114:
           python.version: "3.7"
-          tensorflow.version: "2.0.0-alpha0"
+          tensorflow.version: "1.14.0"
+        Python37_TF2:
+          python.version: "3.7"
+          tensorflow.version: "2.0.0-beta1"
           coverage: "true"
 
     steps:


### PR DESCRIPTION
This PR adds tests against Python 3.6/3.7 and TF 1.13.1/1.14.0/2.0-beta1.
Note that we don't test every possible combination to keep our builds fast.