### PR TITLE
Breaking change: Add support for preload hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To train the models registered above we will need to write a custom training loo
 
 ```python
 @cli.command()
-@build_train
+@build_train()
 def train(build_model, dataset, hparams, output_dir, epochs):
     """Start model training."""
     model = build_model(hparams, dataset)

--- a/zookeeper/cli.py
+++ b/zookeeper/cli.py
@@ -2,9 +2,7 @@ import click
 import click_completion
 import click_completion.core
 import os
-from pathlib import Path
-from datetime import datetime
-from functools import wraps
+import functools
 
 click_completion.init()
 
@@ -66,7 +64,7 @@ def build_train(preload=None):
             default=False,
             help="If you want to split a dataset which only contains a train/test into train/val/test",
         )
-        @wraps(function)
+        @functools.wraps(function)
         def train(
             model_name,
             dataset_name,
@@ -81,6 +79,7 @@ def build_train(preload=None):
             validationset,
             **kwargs,
         ):
+            from datetime import datetime
             from zookeeper import registry
 
             if preload:
@@ -164,6 +163,7 @@ def tensorboard(model, dataset, output_prefix, output_dir):
 )
 def plot(dataset, preprocess_fn, data_dir, output_prefix, format):
     """Plot data examples."""
+    from pathlib import Path
     from zookeeper import registry, data_vis
 
     output_dir = Path(output_prefix).joinpath(dataset, preprocess_fn)

--- a/zookeeper/cli_test.py
+++ b/zookeeper/cli_test.py
@@ -23,7 +23,7 @@ class bar(HParams):
 
 @cli.command()
 @click.option("--custom-opt", type=str, required=True)
-@build_train
+@build_train()
 def train(build_model, dataset, hparams, output_dir, epochs, custom_opt):
     assert isinstance(hparams, HParams)
     assert isinstance(dataset, data.Dataset)
@@ -42,7 +42,7 @@ def train(build_model, dataset, hparams, output_dir, epochs, custom_opt):
 
 
 @cli.command()
-@build_train
+@build_train()
 def train_val(build_model, dataset, hparams, output_dir, epochs):
     assert isinstance(hparams, HParams)
     assert isinstance(dataset, data.Dataset)
@@ -58,7 +58,7 @@ def train_val(build_model, dataset, hparams, output_dir, epochs):
 
 
 @cli.command()
-@build_train
+@build_train()
 def train_fail(build_model, dataset, hparams, output_dir, epochs):
     pass
 


### PR DESCRIPTION
When defining models and data preprocessing in separate files, this hook can be used to lazily import model and data files in order to setup the registry. This can be very useful to speed up shell autocompletion results since TensorFlow takes very long to import and thus would block shell completions if imported normally.

This changes the interface from `@build_train` to `@build_train()` or `@build_train(preload_function)`.